### PR TITLE
Build dependency missing from aws-iot-device-sdk-cpp-v2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ endif()
 
 set(IS_SUBDIRECTORY_INCLUDE true)
 find_package(aws-crt-cpp REQUIRED)
+find_package(aws-c-cpp REQUIRED)
 
 add_subdirectory(jobs)
 add_subdirectory(shadow)

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ cd aws-crt-cpp-build
 cmake -DCMAKE_INSTALL_PREFIX="<path to where you install>" -DCMAKE_PREFIX_PATH="<path to where you install>" -DBUILD_SHARED_LIBS=ON -DBUILD_DEPS=ON ../aws-crt-cpp
 <invoke build command make, msbuild, ninja etc....> install
 cd ..
-mkdir aws-iot-device-sdk-cpp-v2
-cd aws-iot-device-sdk-cpp-v2
+mkdir aws-iot-device-sdk-cpp-v2-build
+cd aws-iot-device-sdk-cpp-v2-build
 cmake -DCMAKE_INSTALL_PREFIX="<path to where you install>" -DCMAKE_PREFIX_PATH="<path to where you install>" -DBUILD_SHARED_LIBS=ON ../aws-iot-device-sdk-cpp-v2
 <invoke build command make, msbuild, ninja etc....> install
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
