### PR TITLE
Updated s_changeShadowValue method

### DIFF
--- a/samples/shadow/shadow_sync/main.cpp
+++ b/samples/shadow/shadow_sync/main.cpp
@@ -87,7 +87,7 @@ static void s_changeShadowValue(
     reported.WithString(shadowProperty, value);
     state.Desired = desired;
     state.Reported = reported;
-    
+
     UpdateShadowRequest updateShadowRequest;
     Aws::Crt::UUID uuid;
     updateShadowRequest.ClientToken = uuid.ToString();

--- a/samples/shadow/shadow_sync/main.cpp
+++ b/samples/shadow/shadow_sync/main.cpp
@@ -91,7 +91,7 @@ static void s_changeShadowValue(
     UpdateShadowRequest updateShadowRequest;
     Aws::Crt::UUID uuid;
     updateShadowRequest.ClientToken = uuid.ToString();
-    updateShadowRequest.ThingName = thingName.c_str();
+    updateShadowRequest.ThingName = thingName;
     updateShadowRequest.State = state;
 
     auto publishCompleted = [thingName, value](int ioErr) {

--- a/samples/shadow/shadow_sync/main.cpp
+++ b/samples/shadow/shadow_sync/main.cpp
@@ -80,20 +80,19 @@ static void s_changeShadowValue(
 {
     fprintf(stdout, "Changing local shadow value to %s.\n", value.c_str());
 
+    ShadowState state;
+    JsonObject desired;
+    desired.WithString(shadowProperty, value);
+    JsonObject reported;
+    reported.WithString(shadowProperty, value);
+    state.Desired = desired;
+    state.Reported = reported;
+    
     UpdateShadowRequest updateShadowRequest;
     Aws::Crt::UUID uuid;
     updateShadowRequest.ClientToken = uuid.ToString();
-
-    JsonObject stateDocument;
-    JsonObject reported;
-    reported.WithString(shadowProperty, value);
-    stateDocument.WithObject("reported", std::move(reported));
-    JsonObject desired;
-    desired.WithString(shadowProperty, value);
-    stateDocument.WithObject("desired", std::move(desired));
-
-    updateShadowRequest.State = std::move(stateDocument);
-    updateShadowRequest.ThingName = thingName;
+    updateShadowRequest.ThingName = thingName.c_str();
+    updateShadowRequest.State = state;
 
     auto publishCompleted = [thingName, value](int ioErr) {
         if (ioErr != AWS_OP_SUCCESS)


### PR DESCRIPTION
Updated s_changeShadowValue method to construct updateShadowRequest using ShadowState instead of using completely JsonObject

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
