### PR TITLE
Fix GreenGrass discovery

### DIFF
--- a/discovery/source/DiscoveryClient.cpp
+++ b/discovery/source/DiscoveryClient.cpp
@@ -124,12 +124,12 @@ namespace Aws
                                 DiscoverResponse response(jsonObject.View());
                                 onDiscoverResponse(&response, AWS_ERROR_SUCCESS, callbackContext->responseCode);
                             }
-                            else if (errorCode)
-                            {
-                                onDiscoverResponse(nullptr, errorCode, callbackContext->responseCode);
-                            }
                             else
                             {
+                                if (!errorCode)
+                                {
+                                    errorCode = AWS_ERROR_UNKNOWN;
+                                }
                                 onDiscoverResponse(nullptr, errorCode, callbackContext->responseCode);
                             }
 

--- a/samples/greengrass/basic_discovery/main.cpp
+++ b/samples/greengrass/basic_discovery/main.cpp
@@ -189,7 +189,7 @@ int main(int argc, char *argv[])
 
             connection = mqttClient.NewConnection(
                 Aws::Iot::MqttClientConnectionConfigBuilder(certificatePath.c_str(), keyPath.c_str())
-                    .WithCertificateAuthority(groupToUse.CAs->at(0).c_str())
+                    .WithCertificateAuthority(ByteCursorFromCString(groupToUse.CAs->at(0).c_str()))
                     .WithPortOverride(connectivityInfo.Port.value())
                     .WithEndpoint(connectivityInfo.HostAddress.value())
                     .Build());


### PR DESCRIPTION
Fixes for issue https://github.com/awslabs/aws-iot-device-sdk-cpp-v2/issues/53

I'm entering backlog tasks to do a better job on each of these fixes:
- aws-crt-cpp and cpp-v2 should be defining their own `AWS_ERROR_` codes, rather than passing `AWS_ERROR_UNKNOWN` whenever something goes wrong outside of c-town.
- `WithCertificateAuthority()` and `OverrideDefaultTrustStore()` functions should have different names for whether you want to load a file or pass a in-imemory buffer. They should not rely on argument overloads.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
